### PR TITLE
Change Slack integration to RocketChat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,21 @@ First of all, clone the giropopos-monitoring repo:
 # git clone git@github.com:badtuxx/giropops-monitoring.git
 ```
 
-Change the information about your Slack account and what room you will send the alerts:
-```
-# vim conf/alertmanager/config.yml
+## Rocket.Chat
 
-route:
-    receiver: 'slack'
+1) Login as admin user and go to: Administration => Integrations => New Integration => Incoming WebHook
 
-receivers:
-    - name: 'slack'
-      slack_configs:
-          - send_resolved: true
-            username: 'YOUR USERNAME'
-            channel: '#YOURCHANNEL'
-            api_url: 'INCOMING WEBHOOK'
-```
+2) Set "Enabled" and "Script Enabled" to "True"
 
-Install Netdata:
+3) Set all channel, icons, etc. as you need
+
+3) Paste contents of [rocketchat/incoming-webhook.js](rocketchat/incoming-webhook.js) into Script field.
+
+4) Create Integration. You;ll see some values apper. Copy WebHook URL and proceed to Alertmanager.
+
+[Rocket.Chat Docs](https://rocket.chat/docs/administrator-guides/integrations/)
+
+## Install Netdata:
 ```
 # bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 ```
@@ -119,5 +117,5 @@ Of course, create new alerts on Prometheus:
 # vim conf/prometheus/alert.rules
 ```
 
-# Ahhhh, Help us to improve it! 
+# Ahhhh, Help us to improve it!
 # Thanks! #VAIIII

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Setting Netdata Exporter configuration in Prometheus:
 
 ```
 
+## Deploy Stack with Docker
+
 Execute deploy to create the stack of giropops-monitoring:
 ```
 # docker stack deploy -c docker-compose.yml giropops
@@ -74,6 +76,8 @@ vpqw3md2lcbr        giropops_prometheus      replicated          1/1            
 
 ```
 
+## Access Services in Browser
+
 To access Prometheus interface on browser:
 ```
 http://YOUR_IP:9090
@@ -90,9 +94,8 @@ http://YOUR_IP:3000
 user: admin
 passwd: giropops
 
-Get fun, access the dashboards! ;)
-
 ```
+Get fun, access the dashboards! ;)
 
 To access Netdata interface on browser:
 ```
@@ -103,6 +106,14 @@ To access Prometheus Node_exporter metrics on browser:
 ```
 http://YOUR_IP:9100/metrics
 ```
+
+To access RocketChat interface on browser:  
+```
+http://YOUR_IP:3080
+> First to register becomes admin
+```
+Remember that RocketChat endpoints and payloads are identical to Slack's, so if you wanna set Grafana alerts, just select a slack alert and give it a RocketChat incoming webhook URL, with no script needed.
+
 
 Test if your alerts are ok:
 ```
@@ -116,6 +127,7 @@ Of course, create new alerts on Prometheus:
 ```
 # vim conf/prometheus/alert.rules
 ```
+
 
 # Ahhhh, Help us to improve it!
 # Thanks! #VAIIII

--- a/conf/rocketchat/incoming-webhook.js
+++ b/conf/rocketchat/incoming-webhook.js
@@ -1,0 +1,54 @@
+class Script {
+
+
+
+    process_incoming_request({
+        request
+    }) {
+        var alertColor = "warning";
+
+        if (request.content.status == "resolved") {
+            alertColor = "good";
+        } else if (request.content.status == "firing") {
+            alertColor = "danger";
+        }
+        console.log(request.content);
+
+        let finFields = [];
+        for (i = 0; i < request.content.alerts.length; i++) {
+            var endVal = request.content.alerts[i];
+            var elem = {
+                title: "alertname: " + endVal.labels.alertname,
+                value: "*instance:* " + endVal.labels.instance,
+                short: false
+            };
+
+            finFields.push(elem);
+            finFields.push({title: "description", value: endVal.annotations.description});
+            finFields.push({title: "summary", value: endVal.annotations.summary});
+        }
+
+
+
+        return {
+            content: {
+
+                username: "Prometheus Alert",
+                attachments: [{
+                    color: alertColor,
+                    title_link: request.content.externalURL,
+                    title: "Prometheus notification",
+                    fields: finFields,
+
+                }]
+
+            }
+        };
+
+        return {
+            error: {
+                success: false
+            }
+        };
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,39 @@ services:
     ports:
       - 3000:3000
 
+# If you already has a RocketChat instance running, just comment the code of rocketchat, mongo and mongo-init-replica services bellow
+  rocketchat:
+    image: rocketchat/rocket.chat:latest
+    restart: unless-stopped
+    volumes:
+      - ./uploads:/app/uploads
+    environment:
+      - PORT=3080
+      - ROOT_URL=http://localhost:3080
+      - MONGO_URL=mongodb://mongo:27017/rocketchat
+      - MONGO_OPLOG_URL=mongodb://mongo:27017/local
+#      - MAIL_URL=smtp://user:pass@smtp.email
+#      - HTTP_PROXY=http://proxy.domain.com
+#      - HTTPS_PROXY=http://proxy.domain.com
+    depends_on:
+      - mongo
+    ports:
+      - 3080:3080
+
+  mongo:
+    image: mongo:3.2
+    restart: unless-stopped
+    volumes:
+     - ./data/db:/data/db
+     #- ./data/dump:/dump
+    command: mongod --smallfiles --oplogSize 128 --replSet rs0
+
+  mongo-init-replica:
+    image: mongo:3.2
+    command: 'mongo mongo/rocketchat --eval "rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})"'
+    depends_on:
+      - mongo
+
 networks:
   frontend:
   backend:

--- a/dockerfiles/alertmanager/conf/config.yml
+++ b/dockerfiles/alertmanager/conf/config.yml
@@ -1,10 +1,10 @@
 route:
-    receiver: 'slack'
+    repeat_interval: 30m
+    group_interval: 30m
+    receiver: 'rocketchat'
 
 receivers:
-    - name: 'slack'
-      slack_configs:
-          - send_resolved: true
-            username: 'YOUR USERNAME'
-            channel: '#YOURCHANNEL'
-            api_url: 'INCOMMING WEBHOOK'
+    - name: 'rocketchat'
+      webhook_configs:
+          - send_resolved: false
+            url: '${WEBHOOK_URL}'


### PR DESCRIPTION
RocketChat is a Free and OpenSource Chat platform builded in javascript that runs inside your infrastructure. It's also a great project with a lot of awesome features, that improves in many ways your monitoring and chatops environment, and gives you the security of hosting your own data.

This pull request adds:
- RocketChat services in docker-compose.yml
- README.md documentation about creating RocketChat's incoming webhook
- `rocketchat` folder with incoming-webhook.js script
Also Changes:
- AlertManager config.yml router from Slack to RocketChat
- Topics in README.md to easily separate session steps.

hope you guys enjoy it =)
