### PR TITLE
Upgrade MongoDB image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,14 +84,14 @@ services:
       - 3080:3080
 
   mongo:
-    image: mongo:3.2
+    image: mongo:3.4.23
     volumes:
      - mongodb_data:/data/db
      #- ./data/dump:/dump
     command: mongod --smallfiles --oplogSize 128 --replSet rs0
 
   mongo-init-replica:
-    image: mongo:3.2
+    image: mongo:3.4.23
     command: 'mongo mongo/rocketchat --eval "rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})"'
     depends_on:
       - mongo


### PR DESCRIPTION
Upgraded MongoDB image to version 3.4.23 because of the following error displayed on the Rocket.Chat log:
![rocketchat-error](https://user-images.githubusercontent.com/13918265/66320625-940ca900-e8f5-11e9-8b08-227f1112f08b.png)
\
It wasn't possible to upgrade to the version 3.6 or greater because of the following problem:
```
IMPORTANT: UPGRADE PROBLEM: The data files need to be fully upgraded to version 3.4 before attempting an upgrade to 3.6; see http://dochub.mongodb.org/core/3.6-upgrade-fcv for more details.
```
\
One way to fix this problem is to do this:
[source](https://forums.rocket.chat/t/solved-trying-to-update-mongodb-from-3-2-to-4-0-in-docker-but-errors/3200/2)
```PowerShell
# starting from 3.2, down the containers and update your mongo version in docker-compose.yml
docker-compose -f /path/to/rocketchat/docker-compose.yml down
sed -i "s/mongo:3.2/mongo:3.4/g" /path/to/rocketchat/docker-compose.yml

# starting up the updated docker-compose.yml will pull new mongo image
docker-compose -f /path/to/rocketchat/docker-compose.yml up -d mongo

# this command will update the db to use the new version features
docker exec -it rocketchat_mongo_1 bash -c 'mongo --eval "db.adminCommand( { setFeatureCompatibilityVersion: "3.4" } )"'

# should see an output like this
{ "ok" : 1 }

# initialize rocketchat server to load new db features and update your data files
# not sure if this step necessary but I'm not taking any risks
docker-compose -f /path/to/rocketchat/docker-compose.yml up -d

# go back to step 1, change values, rinse and repeat!
```
\
\
According to the Rocket.Chat log, MongoDB 3.6 or greater will be necessary to run Rocket.Chat 4.0
\
![rocketchat-warn](https://user-images.githubusercontent.com/13918265/66323635-7b52c200-e8fa-11e9-8038-3a8aeaed62ef.png)
