### PR TITLE
Update cadvisor image address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - 9093:9093
 
   cadvisor:
-    image: google/cadvisor
+    image: gcr.io/google-containers/cadvisor
     hostname: '{{.Node.ID}}'
     volumes:
       - /:/rootfs:ro


### PR DESCRIPTION
DockerHub's cadvisor image is deprecated, using Google registry instead.