### PR TITLE
Fixes #29

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,8 @@ services:
       - 9093:9093
 
   cadvisor:
-    image: google/cadvisor
+    #image: google/cadvisor # DEPRECATED: Please use gcr.io/cadvisor/cadvisor instead.
+    image: gcr.io/cadvisor/cadvisor
     hostname: '{{.Node.ID}}'
     volumes:
       - /:/rootfs:ro


### PR DESCRIPTION
Correção para o erro "Failed to create a Container Manager: mountpoint for cpu not found" no cadvisor ao tentar fazer deploy da stack no docker-compose.yml

![mountpoint-not-found-cadvisor](https://user-images.githubusercontent.com/5115895/207673023-a919949a-d96c-41a8-b7c5-89a1d7867fbf.png)

Para mais detalhes, por favor visite a issue https://github.com/badtuxx/giropops-monitoring/issues/29